### PR TITLE
[pycodestyle] Fix violations

### DIFF
--- a/sktm.py
+++ b/sktm.py
@@ -1,23 +1,25 @@
 #!/usr/bin/python2
 
-# Copyright (c) 2017 Red Hat, Inc. All rights reserved. This copyrighted material
-# is made available to anyone wishing to use, modify, copy, or
+# Copyright (c) 2017 Red Hat, Inc. All rights reserved. This copyrighted
+# material is made available to anyone wishing to use, modify, copy, or
 # redistribute it subject to the terms and conditions of the GNU General
 # Public License v.2 or later.
 #
-# This program is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
-# PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+# along with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 import argparse
 import ConfigParser
-import os
 import logging
+import os
 import sktm
+
 
 def setup_parser():
     """
@@ -49,16 +51,19 @@ def setup_parser():
     parser_patchwork.add_argument("repo", type=str, help="Base repo URL")
     parser_patchwork.add_argument("baseurl", type=str, help="Base URL")
     parser_patchwork.add_argument("project", type=str, help="Project name")
-    parser_patchwork.add_argument("--lastpatch", type=str, help="Last patch (id for pw1; datetime for pw2)")
+    parser_patchwork.add_argument("--lastpatch", type=str, help="Last patch "
+                                  "(id for pw1; datetime for pw2)")
     parser_patchwork.add_argument("--restapi", help="Use REST API",
-                                  action = "store_true", default = False)
-    parser_patchwork.add_argument("--apikey", type=str, help="API key to write down results")
+                                  action="store_true", default=False)
+    parser_patchwork.add_argument("--apikey", type=str,
+                                  help="API key to write down results")
     parser_patchwork.set_defaults(func=cmd_patchwork)
 
     parser_testinfo = subparsers.add_parser("testinfo")
     parser_testinfo.set_defaults(func=cmd_testinfo)
 
     return parser
+
 
 def setup_logging(verbose):
     """
@@ -68,26 +73,32 @@ def setup_logging(verbose):
         verbose:    Verbosity level to setup log message filtering at.
     """
     logger = logging.getLogger()
-    logging.basicConfig(format="[%(process)d] %(asctime)s %(levelname)8s   %(message)s")
+    logging.basicConfig(
+        format="[%(process)d] %(asctime)s %(levelname)8s   %(message)s"
+    )
     logger.setLevel(logging.WARNING - (verbose * 10))
+
 
 def cmd_baseline(sw, cfg):
     logging.info("checking baseline: %s [%s]", cfg.get("repo"), cfg.get("ref"))
     sw.set_baseline(cfg.get("repo"), cfg.get("ref"), cfg.get("cfgurl"))
-    sw.check_baseline();
+    sw.check_baseline()
+
 
 def cmd_patchwork(sw, cfg):
     logging.info("checking patchwork: %s [%s]", cfg.get("repo"),
                  cfg.get("project"))
-    sw.set_baseline(cfg.get("repo"), cfgurl = cfg.get("cfgurl"))
+    sw.set_baseline(cfg.get("repo"), cfgurl=cfg.get("cfgurl"))
     sw.set_restapi(cfg.get("restapi"))
     sw.add_pw(cfg.get("baseurl"), cfg.get("project"), cfg.get("lastpatch"),
               cfg.get("apikey"))
     sw.check_patchwork()
 
+
 def cmd_testinfo(sw, cfg):
     db = sw.db
     db.dump_baserepo_info()
+
 
 def load_config(args):
     config = ConfigParser.ConfigParser()
@@ -96,10 +107,11 @@ def load_config(args):
 
     if config.has_section('config'):
         for (name, value) in config.items('config'):
-            if name not in cfg or cfg.get(name) == None:
+            if name not in cfg or cfg.get(name) is None:
                 cfg[name] = value
 
     return cfg
+
 
 if __name__ == '__main__':
     parser = setup_parser()

--- a/sktm/__init__.py
+++ b/sktm/__init__.py
@@ -1,15 +1,16 @@
-# Copyright (c) 2017 Red Hat, Inc. All rights reserved. This copyrighted material
-# is made available to anyone wishing to use, modify, copy, or
+# Copyright (c) 2017 Red Hat, Inc. All rights reserved. This copyrighted
+# material is made available to anyone wishing to use, modify, copy, or
 # redistribute it subject to the terms and conditions of the GNU General
 # Public License v.2 or later.
 #
-# This program is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
-# PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+# along with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 import enum
 import logging
@@ -20,6 +21,7 @@ import sktm.db
 import sktm.jenkins
 import sktm.patchwork
 
+
 class tresult(enum.IntEnum):
     """Test result"""
     SUCCESS = 0
@@ -29,15 +31,17 @@ class tresult(enum.IntEnum):
     TEST_FAILURE = 4
     BASELINE_FAILURE = 5
 
+
 class jtype(enum.IntEnum):
     """Job type"""
     BASELINE = 0
     PATCHWORK = 1
 
+
 # TODO This is no longer just a watcher. Rename/refactor/describe accordingly.
 class watcher(object):
     def __init__(self, jenkinsurl, jenkinslogin, jenkinspassword,
-                 jenkinsjobname, dbpath, makeopts = None):
+                 jenkinsjobname, dbpath, makeopts=None):
         """
         Initialize a "watcher".
 
@@ -72,7 +76,7 @@ class watcher(object):
         # False if XML RPC-based Patchwork interfaces should be created
         self.restapi = False
 
-    def set_baseline(self, repo, ref = "master", cfgurl = None):
+    def set_baseline(self, repo, ref="master", cfgurl=None):
         """
         Set baseline parameters.
 
@@ -87,7 +91,7 @@ class watcher(object):
 
     # FIXME The argument should not have a default
     # FIXME This function should likely not exist
-    def set_restapi(self, restapi = False):
+    def set_restapi(self, restapi=False):
         """
         Set the type of the next added Patchwork interface.
 
@@ -102,7 +106,7 @@ class watcher(object):
             logging.warning("Quiting before job completion: %d/%d", bid, pjt)
 
     # FIXME Pass patchwork type via arguments, or pass a whole interface
-    def add_pw(self, baseurl, pname, lpatch = None, apikey = None):
+    def add_pw(self, baseurl, pname, lpatch=None, apikey=None):
         """
         Add a Patchwork interface with specified parameters.
         Add an XML RPC-based interface, if self.restapi is false,
@@ -120,26 +124,28 @@ class watcher(object):
         if self.restapi:
             pw = sktm.patchwork.skt_patchwork2(baseurl, pname, lpatch, apikey)
 
-            if lpatch == None:
+            if lpatch is None:
                 lcdate = self.db.get_last_checked_patch_date(baseurl,
                                                              pw.projectid)
                 lpdate = self.db.get_last_pending_patch_date(baseurl,
                                                              pw.projectid)
                 since = max(lcdate, lpdate)
-                if since == None:
-                    raise Exception("%s project: %s was never tested before, please provide initial patch id" %
+                if since is None:
+                    raise Exception("%s project: %s was never tested before, "
+                                    "please provide initial patch id" %
                                     (baseurl, pname))
                 pw.since = since
         else:
             pw = sktm.patchwork.skt_patchwork(baseurl, pname,
                                               int(lpatch) if lpatch else None)
 
-            if lpatch == None:
+            if lpatch is None:
                 lcpatch = self.db.get_last_checked_patch(baseurl, pw.projectid)
                 lppatch = self.db.get_last_pending_patch(baseurl, pw.projectid)
                 lpatch = max(lcpatch, lppatch)
-                if lpatch == None:
-                    raise Exception("%s project: %s was never tested before, please provide initial patch id" %
+                if lpatch is None:
+                    raise Exception("%s project: %s was never tested before, "
+                                    "please provide initial patch id" %
                                     (baseurl, pname))
                 pw.lastpatch = lpatch
         self.pw.append(pw)
@@ -149,17 +155,17 @@ class watcher(object):
         """Submit a build for baseline"""
         self.pj.append((sktm.jtype.BASELINE,
                         self.jk.build(self.jobname,
-                                      baserepo = self.baserepo,
-                                      ref = self.baseref,
-                                      baseconfig = self.cfgurl,
-                                      makeopts = self.makeopts),
+                                      baserepo=self.baserepo,
+                                      ref=self.baseref,
+                                      baseconfig=self.cfgurl,
+                                      makeopts=self.makeopts),
                         None))
 
     def check_patchwork(self):
         stablecommit = self.db.get_stable(self.baserepo)
-        if stablecommit == None:
+        if stablecommit is None:
             raise Exception("No known stable baseline for repo %s" %
-                    self.baserepo)
+                            self.baserepo)
 
         logging.info("stable commit for %s is %s", self.baserepo, stablecommit)
         for cpw in self.pw:
@@ -182,12 +188,12 @@ class watcher(object):
                                              pids)
                 self.pj.append((sktm.jtype.PATCHWORK,
                                 self.jk.build(self.jobname,
-                                              baserepo = self.baserepo,
-                                              ref = stablecommit,
-                                              baseconfig = self.cfgurl,
-                                              patchwork = patchset,
-                                              emails = emails,
-                                              makeopts = self.makeopts),
+                                              baserepo=self.baserepo,
+                                              ref=stablecommit,
+                                              baseconfig=self.cfgurl,
+                                              patchwork=patchset,
+                                              emails=emails,
+                                              makeopts=self.makeopts),
                                 cpw))
                 logging.info("submitted patchset: %s", patchset)
                 logging.debug("emails: %s", emails)
@@ -198,11 +204,13 @@ class watcher(object):
                 logging.info("job completed: jjid=%d; type=%d", bid, pjt)
                 self.pj.remove((pjt, bid, cpw))
                 if pjt == sktm.jtype.BASELINE:
-                    self.db.update_baseline(self.baserepo,
-                            self.jk.get_base_hash(self.jobname, bid),
-                            self.jk.get_base_commitdate(self.jobname, bid),
-                            self.jk.get_result(self.jobname, bid),
-                            bid)
+                    self.db.update_baseline(
+                        self.baserepo,
+                        self.jk.get_base_hash(self.jobname, bid),
+                        self.jk.get_base_commitdate(self.jobname, bid),
+                        self.jk.get_result(self.jobname, bid),
+                        bid
+                    )
                 elif pjt == sktm.jtype.PATCHWORK:
                     patches = list()
                     slist = list()
@@ -214,11 +222,13 @@ class watcher(object):
                     basehash = self.jk.get_base_hash(self.jobname, bid)
                     logging.info("basehash=%s", basehash)
                     if bres == sktm.tresult.BASELINE_FAILURE:
-                        self.db.update_baseline(self.baserepo,
-                                basehash,
-                                self.jk.get_base_commitdate(self.jobname, bid),
-                                sktm.tresult.TEST_FAILURE,
-                                bid)
+                        self.db.update_baseline(
+                            self.baserepo,
+                            basehash,
+                            self.jk.get_base_commitdate(self.jobname, bid),
+                            sktm.tresult.TEST_FAILURE,
+                            bid
+                        )
 
                     patchset = self.jk.get_patchwork(self.jobname, bid)
                     for purl in patchset:
@@ -227,7 +237,7 @@ class watcher(object):
                             baseurl = match.group(1)
                             pid = int(match.group(2))
                             patch = cpw.get_patch_by_id(pid)
-                            if patch == None:
+                            if patch is None:
                                 continue
                             logging.info("patch: [%d] %s", pid,
                                          patch.get("name"))
@@ -239,7 +249,8 @@ class watcher(object):
                                 projid = int(patch.get("project_id"))
                             patches.append((pid, patch.get("name"), purl,
                                             baseurl, projid,
-                                            patch.get("date").replace(" ", "T")))
+                                            patch.get("date").replace(" ",
+                                                                      "T")))
                             cpw.set_patch_check(pid, rurl, bres)
                         else:
                             raise Exception("Malfomed patch url: %s" % purl)

--- a/sktm/db.py
+++ b/sktm/db.py
@@ -1,21 +1,23 @@
-# Copyright (c) 2017 Red Hat, Inc. All rights reserved. This copyrighted material
-# is made available to anyone wishing to use, modify, copy, or
+# Copyright (c) 2017 Red Hat, Inc. All rights reserved. This copyrighted
+# material is made available to anyone wishing to use, modify, copy, or
 # redistribute it subject to the terms and conditions of the GNU General
 # Public License v.2 or later.
 #
-# This program is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
-# PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+# along with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 import logging
 import os
 import sqlite3
 import time
 import sktm
+
 
 class skt_db(object):
     def __init__(self, db):
@@ -110,7 +112,7 @@ class skt_db(object):
                          (baserepo,))
 
         brid = self.cur.fetchone()
-        if brid != None:
+        if brid is not None:
             return brid[0]
 
         self.cur.execute('INSERT INTO baserepo(url) VALUES(?)',
@@ -131,16 +133,17 @@ class skt_db(object):
         Returns:
             Located or created integer ID of the patch source.
         """
-        self.cur.execute('SELECT id FROM patchsource WHERE \
-                          baseurl=? AND \
-                          project_id=?',
+        self.cur.execute('SELECT id FROM patchsource WHERE '
+                         'baseurl=? AND '
+                         'project_id=?',
                          (baseurl, projid))
 
         sid = self.cur.fetchone()
-        if sid != None:
+        if sid is not None:
             return sid[0]
 
-        self.cur.execute('INSERT INTO patchsource(baseurl, project_id) VALUES(?,?)',
+        self.cur.execute('INSERT INTO patchsource(baseurl, project_id) '
+                         'VALUES(?,?)',
                          (baseurl, projid))
         self.conn.commit()
         return self.get_sourceid(baseurl, projid)
@@ -148,60 +151,60 @@ class skt_db(object):
     def get_last_checked_patch(self, baseurl, projid):
         sourceid = self.get_sourceid(baseurl, projid)
 
-        self.cur.execute('SELECT patch.id FROM patch WHERE \
-                            patchsource_id = ? \
-                            ORDER BY id DESC LIMIT 1',
+        self.cur.execute('SELECT patch.id FROM patch WHERE '
+                         'patchsource_id = ? '
+                         'ORDER BY id DESC LIMIT 1',
                          (sourceid,))
         res = self.cur.fetchone()
-        return None if res == None else res[0]
+        return None if res is None else res[0]
 
     def get_last_pending_patch(self, baseurl, projid):
         sourceid = self.get_sourceid(baseurl, projid)
 
-        self.cur.execute('SELECT id FROM pendingpatches WHERE \
-                            patchsource_id = ? \
-                            ORDER BY id DESC LIMIT 1',
+        self.cur.execute('SELECT id FROM pendingpatches WHERE '
+                         'patchsource_id = ? '
+                         'ORDER BY id DESC LIMIT 1',
                          (sourceid,))
         res = self.cur.fetchone()
-        return None if res == None else res[0]
+        return None if res is None else res[0]
 
     def set_event_date(self, baseurl, projid, date):
-        if date == None:
+        if date is None:
             return
         logging.debug("event date: %s %d -> %s", baseurl, projid, date)
-        self.cur.execute('UPDATE patchsource SET date = ? \
-                          WHERE baseurl = ? AND project_id = ?',
+        self.cur.execute('UPDATE patchsource SET date = ? '
+                         'WHERE baseurl = ? AND project_id = ?',
                          (date, baseurl, projid))
         self.conn.commit()
 
     def get_last_event_date(self, baseurl, projid):
-        self.cur.execute('SELECT date FROM patchsource WHERE \
-                            baseurl = ? AND project_id = ?',
+        self.cur.execute('SELECT date FROM patchsource WHERE '
+                         'baseurl = ? AND project_id = ?',
                          (baseurl, projid))
         res = self.cur.fetchone()
-        return None if res == None else res[0]
+        return None if res is None else res[0]
 
     def get_last_checked_patch_date(self, baseurl, projid):
         sourceid = self.get_sourceid(baseurl, projid)
 
-        self.cur.execute('SELECT patch.date FROM patch WHERE \
-                            patchsource_id = ? \
-                            ORDER BY date DESC LIMIT 1',
+        self.cur.execute('SELECT patch.date FROM patch WHERE '
+                         'patchsource_id = ? '
+                         'ORDER BY date DESC LIMIT 1',
                          (sourceid,))
         res = self.cur.fetchone()
-        return None if res == None else res[0]
+        return None if res is None else res[0]
 
     def get_last_pending_patch_date(self, baseurl, projid):
         sourceid = self.get_sourceid(baseurl, projid)
 
-        self.cur.execute('SELECT pdate FROM pendingpatches WHERE \
-                            patchsource_id = ? \
-                            ORDER BY pdate DESC LIMIT 1',
+        self.cur.execute('SELECT pdate FROM pendingpatches WHERE '
+                         'patchsource_id = ? '
+                         'ORDER BY pdate DESC LIMIT 1',
                          (sourceid,))
         res = self.cur.fetchone()
-        return None if res == None else res[0]
+        return None if res is None else res[0]
 
-    def get_expired_pending_patches(self, baseurl, projid, exptime = 86400):
+    def get_expired_pending_patches(self, baseurl, projid, exptime=86400):
         """
         Get a list of IDs of pending patches older than specified time, for a
         combination of a Patchwork base URL and Patchwork project ID.
@@ -219,9 +222,9 @@ class skt_db(object):
         sourceid = self.get_sourceid(baseurl, projid)
         tstamp = int(time.time()) - exptime
 
-        self.cur.execute('SELECT id FROM pendingpatches WHERE \
-                            patchsource_id = ? AND \
-                            timestamp < ?',
+        self.cur.execute('SELECT id FROM pendingpatches WHERE '
+                         'patchsource_id = ? AND '
+                         'timestamp < ?',
                          (sourceid, tstamp))
         for res in self.cur.fetchall():
             patchlist.append(res[0])
@@ -233,33 +236,33 @@ class skt_db(object):
         return patchlist
 
     def get_baselineid(self, brid, commithash):
-        self.cur.execute('SELECT id FROM baseline WHERE \
-                          baserepo_id = ? AND commitid = ?',
-                          (brid, commithash))
+        self.cur.execute('SELECT id FROM baseline WHERE '
+                         'baserepo_id = ? AND commitid = ?',
+                         (brid, commithash))
         res = self.cur.fetchone()
-        return None if res == None else res[0]
+        return None if res is None else res[0]
 
     def get_commitdate(self, baserepo, commitid):
         brid = self.get_repoid(baserepo)
 
-        self.cur.execute('SELECT commitdate FROM baseline WHERE \
-                            commitid = ? AND \
-                            baserepo_id = ?',
+        self.cur.execute('SELECT commitdate FROM baseline WHERE '
+                         'commitid = ? AND '
+                         'baserepo_id = ?',
                          (commitid, brid))
         res = self.cur.fetchone()
-        return None if res == None else res[0]
+        return None if res is None else res[0]
 
     def get_baselineresult(self, baserepo, commithash):
         brid = self.get_repoid(baserepo)
 
-        self.cur.execute('SELECT testrun.result_id FROM baseline, testrun WHERE \
-                            baseline.commitid = ? AND \
-                            baseline.baserepo_id = ? AND \
-                            baseline.testrun_id = testrun.id \
-                            ORDER BY baseline.commitdate DESC LIMIT 1',
+        self.cur.execute('SELECT testrun.result_id FROM baseline, testrun '
+                         'WHERE baseline.commitid = ? AND '
+                         'baseline.baserepo_id = ? AND '
+                         'baseline.testrun_id = testrun.id '
+                         'ORDER BY baseline.commitdate DESC LIMIT 1',
                          (commithash, brid))
         res = self.cur.fetchone()
-        return None if res == None else sktm.tresult(res[0])
+        return None if res is None else sktm.tresult(res[0])
 
     def get_stable(self, baserepo):
         """
@@ -273,26 +276,26 @@ class skt_db(object):
         """
         brid = self.get_repoid(baserepo)
 
-        self.cur.execute('SELECT commitid FROM baseline, testrun WHERE \
-                            baseline.baserepo_id = ? AND \
-                            baseline.testrun_id = testrun.id AND \
-                            testrun.result_id = 0 \
-                            ORDER BY baseline.commitdate DESC LIMIT 1',
+        self.cur.execute('SELECT commitid FROM baseline, testrun WHERE '
+                         'baseline.baserepo_id = ? AND '
+                         'baseline.testrun_id = testrun.id AND '
+                         'testrun.result_id = 0 '
+                         'ORDER BY baseline.commitdate DESC LIMIT 1',
                          (brid, ))
 
         res = self.cur.fetchone()
-        return None if res == None else res[0]
+        return None if res is None else res[0]
 
     def get_latest(self, baserepo):
         brid = self.get_repoid(baserepo)
 
-        self.cur.execute('SELECT commitid FROM baseline WHERE \
-                            baserepo_id = ? \
-                            ORDER BY baseline.commitdate DESC LIMIT 1',
+        self.cur.execute('SELECT commitid FROM baseline WHERE '
+                         'baserepo_id = ? '
+                         'ORDER BY baseline.commitdate DESC LIMIT 1',
                          (brid, ))
 
         res = self.cur.fetchone()
-        return None if res == None else res[0]
+        return None if res is None else res[0]
 
     def set_patchset_pending(self, baseurl, projid, patchset):
         psid = self.get_sourceid(baseurl, projid)
@@ -300,11 +303,12 @@ class skt_db(object):
 
         logging.debug("setting patches as pending: %s", patchset)
 
-        self.cur.executemany('INSERT OR REPLACE INTO \
-                              pendingpatches(id, pdate, patchsource_id, \
-                              timestamp) \
-                              VALUES(?, ?, ?, ?)',
-                             [(pid, pdate, psid, tstamp) for (pid, pdate) in patchset])
+        self.cur.executemany('INSERT OR REPLACE INTO '
+                             'pendingpatches(id, pdate, patchsource_id, '
+                             'timestamp) '
+                             'VALUES(?, ?, ?, ?)',
+                             [(pid, pdate, psid, tstamp) for
+                              (pid, pdate) in patchset])
         self.conn.commit()
 
     def unset_patchset_pending(self, baseurl, projid, patchset):
@@ -312,12 +316,13 @@ class skt_db(object):
 
         logging.debug("removing patches from pending list: %s", patchset)
 
-        self.cur.executemany('DELETE FROM pendingpatches WHERE id = ? \
-                              AND patchsource_id = ?',
+        self.cur.executemany('DELETE FROM pendingpatches WHERE id = ? '
+                             'AND patchsource_id = ?',
                              [(pid, psid) for pid in patchset])
         self.conn.commit()
 
-    def update_baseline(self, baserepo, commithash, commitdate, result, buildid):
+    def update_baseline(self, baserepo, commithash, commitdate,
+                        result, buildid):
         logging.debug("update_baseline: repo=%s; commit=%s; result=%s",
                       baserepo, commithash, result)
         brepoid = self.get_repoid(baserepo)
@@ -326,33 +331,33 @@ class skt_db(object):
 
         prev_res = self.get_baselineresult(baserepo, commithash)
         logging.debug("previous result: %s", prev_res)
-        if prev_res == None:
-            self.cur.execute('INSERT INTO \
-                              baseline(baserepo_id, commitid, commitdate, testrun_id) \
-                              VALUES(?,?,?,?)',
+        if prev_res is None:
+            self.cur.execute('INSERT INTO '
+                             'baseline(baserepo_id, commitid, commitdate, '
+                             'testrun_id) VALUES(?,?,?,?)',
                              (brepoid, commithash, commitdate, testrunid))
         elif result >= prev_res:
-            self.cur.execute('UPDATE baseline SET testrun_id = ? \
-                              WHERE commitid = ? AND baserepo_id = ?',
+            self.cur.execute('UPDATE baseline SET testrun_id = ? '
+                             'WHERE commitid = ? AND baserepo_id = ?',
                              (testrunid, commithash, brepoid))
         self.conn.commit()
 
     # FIXME: There is a chance of series_id collisions between different
     # patchwork instances
     def get_series_result(self, series_id):
-        self.cur.execute('SELECT testrun.result_id FROM patchtest, testrun \
-                            WHERE patchtest.patch_series_id = ? \
-                            AND patchtest.testrun_id = testrun.id \
-                            LIMIT 1',
+        self.cur.execute('SELECT testrun.result_id FROM patchtest, testrun '
+                         'WHERE patchtest.patch_series_id = ? '
+                         'AND patchtest.testrun_id = testrun.id '
+                         'LIMIT 1',
                          (series_id, ))
 
         res = self.cur.fetchone()
-        return None if res == None else res[0]
+        return None if res is None else res[0]
 
     def commit_patchtest(self, baserepo, commithash, patches, result, buildid,
-                         series = None):
-        logging.debug("commit_patchtest: repo=%s; commit=%s; patches=%d; result=%s",
-                      baserepo, commithash, len(patches), result)
+                         series=None):
+        logging.debug("commit_patchtest: repo=%s; commit=%s; patches=%d; "
+                      "result=%s", baserepo, commithash, len(patches), result)
         brepoid = self.get_repoid(baserepo)
         baselineid = self.get_baselineid(brepoid, commithash)
         testrunid = self.commit_testrun(result, buildid)
@@ -363,18 +368,20 @@ class skt_db(object):
             # one
             self.unset_patchset_pending(baseurl, projid, [pid])
 
-        self.cur.execute('INSERT INTO \
-                          patchtest(patch_series_id, baseline_id, testrun_id) \
-                          VALUES(?,?,?)',
+        self.cur.execute('INSERT INTO '
+                         'patchtest(patch_series_id, baseline_id, testrun_id) '
+                         'VALUES(?,?,?)',
                          (seriesid, baselineid, testrunid))
         self.conn.commit()
 
     def commit_testrun(self, result, buildid):
         logging.debug("commit_testrun: result=%s; buildid=%d", result, buildid)
-        self.cur.execute('INSERT INTO testrun(result_id, build_id) VALUES(?,?)',
+        self.cur.execute('INSERT INTO testrun(result_id, build_id) '
+                         'VALUES(?,?)',
                          (result.value, buildid))
 
-        self.cur.execute('SELECT id FROM testrun WHERE result_id=? AND build_id=?',
+        self.cur.execute('SELECT id FROM testrun WHERE result_id=? AND '
+                         'build_id=?',
                          (result.value, buildid))
 
         testrunid = self.cur.fetchone()[0]
@@ -385,21 +392,21 @@ class skt_db(object):
     def commit_patch(self, pid, pname, purl, sid, baseurl, projid, pdate):
         logging.debug("commit_patch: pid=%s; sid=%s", pid, sid)
         sourceid = self.get_sourceid(baseurl, projid)
-        self.cur.execute('INSERT OR REPLACE INTO \
-                          patch(id, name, url, patchsource_id, series_id, date) \
-                          VALUES(?,?,?,?,?,?)',
+        self.cur.execute('INSERT OR REPLACE INTO patch(id, name, url, '
+                         'patchsource_id, series_id, date) '
+                         'VALUES(?,?,?,?,?,?)',
                          (pid, pname, purl, sourceid, sid, pdate))
         self.conn.commit()
 
-    def commit_series(self, patches, seriesid = None):
+    def commit_series(self, patches, seriesid=None):
         logging.debug("commit_series: %s (%s)", patches, seriesid)
-        if seriesid == None:
+        if seriesid is None:
             seriesid = 1
-            self.cur.execute('SELECT series_id FROM patch \
-                              ORDER BY series_id DESC LIMIT 1')
+            self.cur.execute('SELECT series_id FROM patch '
+                             'ORDER BY series_id DESC LIMIT 1')
             res = self.cur.fetchone()
-            if res != None:
-                 seriesid = 1 + res[0]
+            if res is not None:
+                seriesid = 1 + res[0]
 
         for (pid, pname, purl, baseurl, projid, pdate) in patches:
             sourceid = self.get_sourceid(baseurl, projid)
@@ -411,11 +418,11 @@ class skt_db(object):
         return seriesid
 
     def dump_baseline_tests(self):
-        self.cur.execute('SELECT baserepo.url, baseline.commitid, \
-                          testrun.result_id, testrun.build_id \
-                          FROM baseline, baserepo, testrun \
-                          WHERE baseline.baserepo_id = baserepo.id AND \
-                          baseline.testrun_id = testrun.id')
+        self.cur.execute('SELECT baserepo.url, baseline.commitid, '
+                         'testrun.result_id, testrun.build_id '
+                         'FROM baseline, baserepo, testrun '
+                         'WHERE baseline.baserepo_id = baserepo.id AND '
+                         'baseline.testrun_id = testrun.id')
 
         for (burl, commit, res, buildid) in self.cur.fetchall():
             print "repo url: %s" % burl
@@ -425,14 +432,16 @@ class skt_db(object):
             print "---"
 
     def dump_baserepo_info(self):
-        self.cur.execute('SELECT url FROM baserepo');
+        self.cur.execute('SELECT url FROM baserepo')
 
         for (burl,) in self.cur.fetchall():
             print "repo url: %s" % burl
             stable = self.get_stable(burl)
             latest = self.get_latest(burl)
-            print "most recent stable commit: %s (%s)" % (stable,
-                    self.get_commitdate(burl, stable))
-            print "most recent tested commit: %s (%s)" % (latest,
-                    self.get_commitdate(burl, latest))
+            print "most recent stable commit: %s (%s)" % (
+                stable, self.get_commitdate(burl, stable)
+            )
+            print "most recent tested commit: %s (%s)" % (
+                latest, self.get_commitdate(burl, latest)
+            )
             print "---"

--- a/sktm/jenkins.py
+++ b/sktm/jenkins.py
@@ -1,15 +1,16 @@
-# Copyright (c) 2017 Red Hat, Inc. All rights reserved. This copyrighted material
-# is made available to anyone wishing to use, modify, copy, or
+# Copyright (c) 2017 Red Hat, Inc. All rights reserved. This copyrighted
+# material is made available to anyone wishing to use, modify, copy, or
 # redistribute it subject to the terms and conditions of the GNU General
 # Public License v.2 or later.
 #
-# This program is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
-# PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+# along with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 import jenkinsapi
 import json
@@ -17,9 +18,10 @@ import logging
 import time
 import sktm
 
+
 class skt_jenkins(object):
     """Jenkins interface"""
-    def __init__(self, url, username = None, password = None):
+    def __init__(self, url, username=None, password=None):
         """
         Initialize a Jenkins interface.
 
@@ -41,7 +43,7 @@ class skt_jenkins(object):
 
         return build
 
-    def get_cfg_data(self, jobname, buildid, stepname, cfgkey, default = None):
+    def get_cfg_data(self, jobname, buildid, stepname, cfgkey, default=None):
         """
         Get a value from a JSON-formatted output of a test result, of the
         specified completed build for the specified project. Wait for the
@@ -141,7 +143,8 @@ class skt_jenkins(object):
                             build.get_status()))
 
         if bstatus == "UNSTABLE" and \
-                (build.get_resultset()["skt.cmd_run"].status in  ["PASSED", "FIXED"]):
+                (build.get_resultset()["skt.cmd_run"].status in
+                 ["PASSED", "FIXED"]):
             if self.get_baseretcode(jobname, buildid) != 0:
                 logging.warning("baseline failure found during patch testing")
                 return sktm.tresult.BASELINE_FAILURE
@@ -165,8 +168,8 @@ class skt_jenkins(object):
         return sktm.tresult.TEST_FAILURE
 
     # FIXME Clarify/fix argument names
-    def build(self, jobname, baserepo = None, ref = None, baseconfig = None,
-              patchwork = [], emails = set(), makeopts = None):
+    def build(self, jobname, baserepo=None, ref=None, baseconfig=None,
+              patchwork=[], emails=set(), makeopts=None):
         """
         Submit a build of a patchset.
 
@@ -185,16 +188,16 @@ class skt_jenkins(object):
             Submitted build number.
         """
         params = dict()
-        if baserepo != None:
+        if baserepo is not None:
             params["baserepo"] = baserepo
 
-        if ref != None:
+        if ref is not None:
             params["ref"] = ref
 
-        if baseconfig != None:
+        if baseconfig is not None:
             params["baseconfig"] = baseconfig
 
-        if makeopts != None:
+        if makeopts is not None:
             params["makeopts"] = makeopts
 
         if len(patchwork) > 0:
@@ -219,8 +222,8 @@ class skt_jenkins(object):
 
     def _params_eq(self, build, params):
         result = True
-        if build == None or build.get_actions() == None or \
-                build.get_actions().get("parameters") == None:
+        if build is None or build.get_actions() is None or \
+                build.get_actions().get("parameters") is None:
             return False
 
         for param in build.get_actions().get("parameters"):
@@ -231,7 +234,7 @@ class skt_jenkins(object):
 
         return result
 
-    def find_build(self, jobname, params, eid = None):
+    def find_build(self, jobname, params, eid=None):
         job = self.server.get_job(jobname)
 
         try:
@@ -239,14 +242,14 @@ class skt_jenkins(object):
         except jenkinsapi.custom_exceptions.NoBuildData:
             lbuild = None
 
-        while lbuild == None:
+        while lbuild is None:
             time.sleep(1)
             try:
                 lbuild = job.get_last_build()
             except jenkinsapi.custom_exceptions.NoBuildData:
                 lbuild = None
 
-        if eid != None:
+        if eid is not None:
             while lbuild.get_number() < eid:
                 time.sleep(1)
                 lbuild = job.get_last_build()


### PR DESCRIPTION
This patch fixes the gigantic number of syntax (mainly pep8) violations,
namely:
- whitespace issues (whitespaces present around keyword arguments or
  before ':', number of blank lines, missing space after '#' in comment,
  ...)
- conditionals: comparisons with None, True, False
- too long lines (>79 chars)
- semicolons (?!)
- indentation

The patch doesn't fix any 'non-pythonic' code, it just makes the first
step towards it with correcting the syntax issues.

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>