### PR TITLE
Don't use specific REST API version with Patchwork

### DIFF
--- a/sktm/patchwork.py
+++ b/sktm/patchwork.py
@@ -175,7 +175,7 @@ class skt_patchwork2(object):
         Returns:
             The JSON representation of the API URLs.
         """
-        r = requests.get("%s/api/1.0" % self.baseurl)
+        r = requests.get("%s/api" % self.baseurl)
         if r.status_code != 200:
             raise Exception("Can't get apiurls: %d" % r.status_code)
 


### PR DESCRIPTION
Recently, Patchwork started enforcing API versioning, meaning that
anyone using older API version won't have access to newly added fields.
If the version is not specified in the URL, newest is assumed. Let's
remove the (old) specific version from the calls to avoid any problems
in the future, while still keeping backwards compatibility.

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>