### PR TITLE
Fix pycodestyle deprecation warning

### DIFF
--- a/sktm/__init__.py
+++ b/sktm/__init__.py
@@ -176,7 +176,7 @@ class watcher(object):
             for (patchset, emails) in patchsets:
                 pids = list()
                 for purl in patchset:
-                    match = re.match("(.*)/patch/(\d+)$", purl)
+                    match = re.match(r"(.*)/patch/(\d+)$", purl)
                     if match:
                         # TODO Shouldn't we be getting this from Patchwork in
                         # the first place, when calling get_patchsets()?
@@ -232,7 +232,7 @@ class watcher(object):
 
                     patchset = self.jk.get_patchwork(self.jobname, bid)
                     for purl in patchset:
-                        match = re.match("(.*)/patch/(\d+)$", purl)
+                        match = re.match(r"(.*)/patch/(\d+)$", purl)
                         if match:
                             baseurl = match.group(1)
                             pid = int(match.group(2))

--- a/sktm/patchwork.py
+++ b/sktm/patchwork.py
@@ -28,12 +28,12 @@ import sktm
 # TODO Move common code to a common parent class
 
 SKIP_PATTERNS = [
-        "\[[^\]]*iproute.*?\]",
-        "\[[^\]]*pktgen.*?\]",
-        "\[[^\]]*ethtool.*?\]",
-        "\[[^\]]*git.*?\]",
-        "\[[^\]]*pull.*?\]",
-        "pull.?request"
+    r"\[[^\]]*iproute.*?\]",
+    r"\[[^\]]*pktgen.*?\]",
+    r"\[[^\]]*ethtool.*?\]",
+    r"\[[^\]]*git.*?\]",
+    r"\[[^\]]*pull.*?\]",
+    r"pull.?request"
 ]
 
 
@@ -208,7 +208,7 @@ class skt_patchwork2(object):
                 for faddr in [x.strip() for x in headers[header].split(",")]:
                     logging.debug("patch=%d; header=%s; email=%s", pid, header,
                                   faddr)
-                    maddr = re.search("\<([^\>]+)\>", faddr)
+                    maddr = re.search(r"\<([^\>]+)\>", faddr)
                     if maddr:
                         emails.add(maddr.group(1))
                     else:
@@ -725,7 +725,7 @@ class skt_patchwork(object):
                 for faddr in [x.strip() for x in mbox[header].split(",")]:
                     logging.debug("patch=%d; header=%s; email=%s", pid, header,
                                   faddr)
-                    maddr = re.search("\<([^\>]+)\>", faddr)
+                    maddr = re.search(r"\<([^\>]+)\>", faddr)
                     if maddr:
                         emails.add(maddr.group(1))
                     else:
@@ -809,7 +809,7 @@ class skt_patchwork(object):
 
         emails = self.get_patch_emails(pid)
 
-        smatch = re.search("\[.*?(\d+)/(\d+).*?\]", pname)
+        smatch = re.search(r"\[.*?(\d+)/(\d+).*?\]", pname)
         if smatch:
             cpatch = int(smatch.group(1))
             mpatch = int(smatch.group(2))
@@ -822,7 +822,7 @@ class skt_patchwork(object):
 
             mid = patch.get("msgid")
 
-            mmatch = re.match("\<(\d+\W\d+)\W\d+.*@", mid)
+            mmatch = re.match(r"\<(\d+\W\d+)\W\d+.*@", mid)
             seriesid = None
             if mmatch:
                 seriesid = mmatch.group(1)


### PR DESCRIPTION
Usage of invalid escape sequences in strings is deprecated since
Python 3.6, which makes pycodestyle complain about regexes.

Docstrings in pycodestyle itself advise usage of raw strings for this
use case:

Okay: regex = r'\.png$'
W605: regex = '\.png$'

So, mark all regular expressions with backslashes as raw strings.

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>