### PR TITLE
Log Patchwork base URL when checking

### DIFF
--- a/sktm.py
+++ b/sktm.py
@@ -86,7 +86,7 @@ def cmd_baseline(sw, cfg):
 
 
 def cmd_patchwork(sw, cfg):
-    logging.info("checking patchwork: %s [%s]", cfg.get("repo"),
+    logging.info("checking patchwork: %s [%s]", cfg.get("baseurl"),
                  cfg.get("project"))
     sw.set_baseline(cfg.get("repo"), cfgurl=cfg.get("cfgurl"))
     sw.set_restapi(cfg.get("restapi"))


### PR DESCRIPTION
Switch to logging the Patchwork base URL as "patchwork" in handling the
"patchwork" command, instead of Git repo URL (mistakenly?) logged
currently. This allows us to distinguish which patchwork is being
handled in the logs.