### PR TITLE
Remove unused DB column and related methods

### DIFF
--- a/sktm/db.py
+++ b/sktm/db.py
@@ -48,8 +48,7 @@ class skt_db(object):
                 CREATE TABLE patchsource(
                   id INTEGER PRIMARY KEY,
                   baseurl TEXT,
-                  project_id INTEGER,
-                  date TEXT
+                  project_id INTEGER
                 );
 
                 CREATE TABLE patch(
@@ -168,22 +167,6 @@ class skt_db(object):
                          'patchsource_id = ? '
                          'ORDER BY id DESC LIMIT 1',
                          (sourceid,))
-        res = self.cur.fetchone()
-        return None if res is None else res[0]
-
-    def set_event_date(self, baseurl, projid, date):
-        if date is None:
-            return
-        logging.debug("event date: %s %d -> %s", baseurl, projid, date)
-        self.cur.execute('UPDATE patchsource SET date = ? '
-                         'WHERE baseurl = ? AND project_id = ?',
-                         (date, baseurl, projid))
-        self.conn.commit()
-
-    def get_last_event_date(self, baseurl, projid):
-        self.cur.execute('SELECT date FROM patchsource WHERE '
-                         'baseurl = ? AND project_id = ?',
-                         (baseurl, projid))
         res = self.cur.fetchone()
         return None if res is None else res[0]
 


### PR DESCRIPTION
The functionality was a residue of previous implementation for
event-based patch retrieval for Patchwork2 and is no longer used or
referenced anywhere. Even if we switched back to even-based patch
retrieval, timestamp of last patch retrieved is saved in the Patchwork
class instance now, not database.

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>