### PR TITLE
Fix bug with pending patch removal

### DIFF
--- a/sktm/__init__.py
+++ b/sktm/__init__.py
@@ -241,7 +241,7 @@ class watcher(object):
             # For each patchset summary
             for patchset in patchsets:
                 # (Re-)add the patchset's patches to the "pending" list
-                self.db.set_patchset_pending(cpw.baseurl, cpw.projectid,
+                self.db.set_patchset_pending(cpw.baseurl,
                                              patchset.get_patch_info_list())
                 # Submit and remember a Jenkins build for the patchset
                 self.pj.append((sktm.jtype.PATCHWORK,

--- a/sktm/db.py
+++ b/sktm/db.py
@@ -64,7 +64,7 @@ class skt_db(object):
                 CREATE TABLE pendingpatches(
                   id INTEGER PRIMARY KEY,
                   pdate TEXT,
-                  patchsource_id INTEGER,
+                  baseurl TEXT,
                   timestamp INTEGER,
                   FOREIGN KEY(patchsource_id) REFERENCES patchsource(id)
                 );
@@ -286,53 +286,46 @@ class skt_db(object):
         res = self.cur.fetchone()
         return None if res is None else res[0]
 
-    def set_patchset_pending(self, baseurl, projid, patchset):
+    def set_patchset_pending(self, baseurl, patchset):
         """
         Add each specified patch to the list of "pending" patches, with
-        specifed patch date, for specified Patchwork base URL and project ID,
-        and marked with current timestamp. Replace any previously added
-        patches with the same ID (bug: should be "same ID, project ID and
-        base URL").
+        specifed patch date, for specified Patchwork base URL, and marked with
+        current timestamp. Replace any previously added patches with the same
+        ID (bug: should be "same ID and base URL").
 
         Args:
             baseurl:    Base URL of the Patchwork instance the project ID and
                         patch IDs belong to.
-            projid:     ID of the Patchwork project the patch IDs belong to.
             patchset:   List of info tuples for patches to add to the list,
                         where each tuple contains the patch ID and a free-form
                         patch date string.
         """
-        psid = self.get_sourceid(baseurl, projid)
         tstamp = int(time.time())
 
         logging.debug("setting patches as pending: %s", patchset)
 
         self.cur.executemany('INSERT OR REPLACE INTO '
-                             'pendingpatches(id, pdate, patchsource_id, '
-                             'timestamp) '
+                             'pendingpatches(id, pdate, baseurl, timestamp) '
                              'VALUES(?, ?, ?, ?)',
-                             [(pid, pdate, psid, tstamp) for
+                             [(pid, pdate, baseurl, tstamp) for
                               (pid, pdate) in patchset])
         self.conn.commit()
 
-    def unset_patchset_pending(self, baseurl, projid, patchset):
+    def unset_patchset_pending(self, baseurl, patchset):
         """
         Remove each specified patch from the list of "pending" patches, for
-        the specified Patchwork base URL and project ID.
+        the specified Patchwork base URL.
 
         Args:
-            baseurl:    Base URL of the Patchwork instance the project ID and
-                        patch IDs belong to.
-            projid:     ID of the Patchwork project the patch IDs belong to.
+            baseurl:    Base URL of the Patchwork instance the patch IDs
+                        belong to.
             patchset:   List of IDs of patches to be removed from the list.
         """
-        psid = self.get_sourceid(baseurl, projid)
-
         logging.debug("removing patches from pending list: %s", patchset)
 
         self.cur.executemany('DELETE FROM pendingpatches WHERE id = ? '
-                             'AND patchsource_id = ?',
-                             [(pid, psid) for pid in patchset])
+                             'AND baseurl = ?',
+                             [(pid, baseurl) for pid in patchset])
         self.conn.commit()
 
     def update_baseline(self, baserepo, commithash, commitdate,
@@ -380,7 +373,7 @@ class skt_db(object):
         for (pid, pname, purl, baseurl, projid, pdate) in patches:
             # TODO: Can accumulate per-project list instead of doing it one by
             # one
-            self.unset_patchset_pending(baseurl, projid, [pid])
+            self.unset_patchset_pending(baseurl, [pid])
 
         self.cur.execute('INSERT INTO '
                          'patchtest(patch_series_id, baseline_id, testrun_id) '


### PR DESCRIPTION
If the patch moved between Patchwork projects during the time it's being
tested, it gets stuck in the pending patch table. Since patch IDs are
unique per instance (and don't depend on the project), change the
pending patch table to contain Patchwork instance's base URL instead of
ID of (base URL, patch ID) pair. Besides solving the problem around
project changes, this also simplifies the lookup.

Fixes #57

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>