### PR TITLE
Add initial tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,6 @@ script:
     - find -name '*.py' | xargs -l1 -IFILE python -c 'import imp; imp.load_source("", "FILE")'
     # Check coding style
     - flake8 --show-source .
+    - coverage run --source=sktm,tests -m pytest -v -s .
+    - coverage report -m --omit="*/tests*"
+    - coveralls

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,6 @@
+coverage
+coveralls
 flake8
+mock
+pytest
 requests

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2018 Red Hat, Inc. All rights reserved. This copyrighted
+# material is made available to anyone wishing to use, modify, copy, or
+# redistribute it subject to the terms and conditions of the GNU General Public
+# License v.2 or later.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+"""Tests for the __init__.py."""
+import tempfile
+import unittest
+
+import mock
+from mock import Mock
+
+import sktm
+
+
+class TestInit(unittest.TestCase):
+    """Test cases for the __init__ module."""
+
+    @mock.patch('sktm.jenkins.skt_jenkins', Mock())
+    def setUp(self):
+        """Test fixtures for testing __init__."""
+        self.database_dir = tempfile.mkdtemp()
+        self.database_file = "{}/testdb.sqlite".format(self.database_dir)
+
+        self.watcher_obj = sktm.watcher(
+            jenkinsurl="http://example.com/jenkins",
+            jenkinslogin="username",
+            jenkinspassword="password",
+            jenkinsjobname="sktm_jenkins_job",
+            dbpath=self.database_file,
+            filter=None,
+            makeopts=None
+        )
+
+    @mock.patch('logging.warning')
+    def test_cleanup(self, mock_logger):
+        """Ensure cleanup() logs a warning."""
+        self.watcher_obj.pj = [(1, 2, 3)]
+        self.watcher_obj.cleanup()
+        mock_logger.assert_called_with(
+            "Quiting before job completion: %d/%d", 2, 1
+        )
+
+    def test_set_baseline(self):
+        """Ensure set_baseline() sets variables properly."""
+        baserepo = 'git://example.com/repo'
+        baseref = 'master'
+        cfgurl = "http://example.com/config.txt"
+
+        self.watcher_obj.set_baseline(
+            repo=baserepo,
+            ref=baseref,
+            cfgurl=cfgurl
+        )
+        self.assertEqual(self.watcher_obj.baserepo, baserepo)
+        self.assertEqual(self.watcher_obj.baseref, baseref)
+        self.assertEqual(self.watcher_obj.cfgurl, cfgurl)
+
+    def test_set_restapi(self):
+        """Ensure set_restapi() sets self.restapi properly."""
+        self.watcher_obj.set_restapi(True)
+        self.assertEqual(self.watcher_obj.restapi, True)
+
+    @mock.patch('sktm.watcher.check_pending', Mock(return_value=True))
+    @mock.patch('logging.info')
+    def test_wait_for_pending_done(self, mock_logging):
+        """Ensure wait_for_pending() logs a message when jobs are complete."""
+        self.watcher_obj.wait_for_pending()
+        mock_logging.assert_called_with('no more pending jobs')


### PR DESCRIPTION
This PR adds initial tests for sktm and uses `pytest` to run them. We can run the tests with plain `unittest` later, but `pytest` gives us some nice features we could use.

- [x] Requires #64 to merge first to fix the foreign key error