### PR TITLE
Db: Remove patchsource_id FOREIGN KEY

### DIFF
--- a/sktm/db.py
+++ b/sktm/db.py
@@ -65,8 +65,7 @@ class skt_db(object):
                   id INTEGER PRIMARY KEY,
                   pdate TEXT,
                   baseurl TEXT,
-                  timestamp INTEGER,
-                  FOREIGN KEY(patchsource_id) REFERENCES patchsource(id)
+                  timestamp INTEGER
                 );
 
                 CREATE TABLE testrun(


### PR DESCRIPTION
The `patchsource_id` column was removed in #58 but the `FOREIGN KEY`
constraint is still present.

Fixes #63.

Signed-off-by: Major Hayden <major@redhat.com>