### PR TITLE
Revert pending patches fixes

### DIFF
--- a/sktm/__init__.py
+++ b/sktm/__init__.py
@@ -241,7 +241,7 @@ class watcher(object):
             # For each patchset summary
             for patchset in patchsets:
                 # (Re-)add the patchset's patches to the "pending" list
-                self.db.set_patchset_pending(cpw.baseurl,
+                self.db.set_patchset_pending(cpw.baseurl, cpw.projectid,
                                              patchset.get_patch_info_list())
                 # Submit and remember a Jenkins build for the patchset
                 self.pj.append((sktm.jtype.PATCHWORK,

--- a/sktm/db.py
+++ b/sktm/db.py
@@ -65,7 +65,8 @@ class skt_db(object):
                   id INTEGER PRIMARY KEY,
                   pdate TEXT,
                   baseurl TEXT,
-                  timestamp INTEGER
+                  timestamp INTEGER,
+                  FOREIGN KEY(patchsource_id) REFERENCES patchsource(id)
                 );
 
                 CREATE TABLE testrun(


### PR DESCRIPTION
Revert the partial fix for stuck pending patches introduced in #58 and #64, as they are breaking adding pending patches with the old database schema, while also not having last pending patch retrieval working with the new schema (as corresponding functions still use the old columns).

Please redo the fix. While at it, please also describe the upgrade routine.

Meanwhile I need to deliver something working to staging, sorry.