### PR TITLE
patchwork: Use /mbox4 mbox URLs with RH fork

### DIFF
--- a/sktm/patchwork.py
+++ b/sktm/patchwork.py
@@ -772,6 +772,8 @@ class skt_patchwork(object):
             projectname:    Patchwork project name, or None.
             lastpatch:      Maximum processed patch ID to start with.
         """
+        # A list of patch object fields to request from RH fork of Patchwork
+        # Only set if it's a RH fork.
         self.fields = None
         # XML RPC interface to Patchwork
         self.rpc = self.get_rpc(baseurl)


### PR DESCRIPTION
Use "/mbox4" mbox URLs with Red Hat Patchwork fork.

Red Hat fork of Patchwork V1 serves unmodified mbox files over a URL
ending with "/mbox4", not "/mbox", and that's what we need in patch
filtering.