### PR TITLE
Fix bug with pending patch removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,21 @@ tested patch recorded, and further patches could be tested by executing the
 However, it can be used again to push the last tested patch back, and retest
 already-tested patches, or to push it forward to skip testing some patches.
 
+### Database upgrading
+
+In case database schema changes, new migration scripts will be provided in
+`db_migrations` directory. They aren't needed for new checkouts, but are
+required for sktm to work correctly when upgrading. New scripts since the last
+upgrade should be applied in the correct (numerical) order with commands:
+
+    sqlite3 <db_path> < <script_name>
+
+For example, if the database path is `.sktm.db` and migration `01-pending.sql`
+is being applied, the command will be
+
+    sqlite3 ~/.sktm.db < 01-pending.sql
+
+
 License
 -------
 sktm is distributed under GPLv2 license.

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -518,7 +518,7 @@ class TestDb(unittest.TestCase):  # pylint: disable=too-many-public-methods
         testdb = skt_db(self.database_file)
         mock_get_sourceid.return_value = 1
 
-        testdb.unset_patchset_pending('baseurl', '1', ['1'])
+        testdb.unset_patchset_pending('baseurl', ['1'])
 
         # Ensure a debug log was written
         mock_log.assert_called_once()
@@ -527,7 +527,7 @@ class TestDb(unittest.TestCase):  # pylint: disable=too-many-public-methods
         execute_call_args = mock_sql.connect().cursor().executemany.\
             call_args[0]
         self.assertIn('DELETE FROM pendingpatches', execute_call_args[0])
-        self.assertEqual([('1', 1)], execute_call_args[1])
+        self.assertEqual([('baseurl', '1')], execute_call_args[1])
 
         # Ensure the data was committed to the database
         mock_sql.connect().commit.assert_called()


### PR DESCRIPTION
 Fix bug with pending patch removal

If the patch moved between Patchwork projects during the time it's being
tested, it gets stuck in the pending patch table. Since patch IDs are
unique per instance (and don't depend on the project), change the
pending patch table to contain Patchwork instance's base URL in addition
to ID of (base URL, patch ID) pair. This solves the problem with patch
removal from pending table, while keeps the original information needed
for proper testing.

Also introduce a way to migrate the database after upgrades since it's
needed for this change.

Fixes #57

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>