### PR TITLE
DB simplification

### DIFF
--- a/db_migrations/01-drop-patchtest.sql
+++ b/db_migrations/01-drop-patchtest.sql
@@ -1,0 +1,1 @@
+DROP TABLE patchtest;

--- a/sktm/__init__.py
+++ b/sktm/__init__.py
@@ -356,8 +356,7 @@ class watcher(object):
                         pass
 
                     if bres != sktm.tresult.BASELINE_FAILURE:
-                        self.db.commit_patchtest(self.baserepo, basehash,
-                                                 patches, bres, bid, series)
+                        self.db.commit_tested(patches, series)
                 else:
                     raise Exception("Unknown job type: %d" % pjt)
 

--- a/sktm/db.py
+++ b/sktm/db.py
@@ -491,27 +491,6 @@ class SktDb(object):
                              (testrun_id, commithash, baserepo_id))
             self.conn.commit()
 
-    # FIXME: There is a chance of series_id collisions between different
-    # patchwork instances
-    def get_series_result(self, series_id):
-        """Get a result_id from a testrun of a patch series.
-
-        Args:
-            series_id:  Series ID from Patchwork.
-
-        """
-        self.cur.execute('SELECT testrun.result_id FROM patchtest, testrun '
-                         'WHERE patchtest.patch_series_id = ? '
-                         'AND patchtest.testrun_id = testrun.id '
-                         'LIMIT 1',
-                         (series_id, ))
-        result = self.cur.fetchone()
-
-        if not result:
-            return None
-
-        return result[0]
-
     def commit_patchtest(self, baserepo, commithash, patches, result,
                          build_id, series=None):
         """Add a patchtest for a patch.

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -64,41 +64,6 @@ class TestDb(unittest.TestCase):  # pylint: disable=too-many-public-methods
         # Ensure the data was committed to the database
         mock_sql.connect().commit.assert_called()
 
-    @mock.patch('sktm.db.SktDb.unset_patchset_pending')
-    @mock.patch('sktm.db.SktDb.commit_series')
-    @mock.patch('sktm.db.SktDb.get_baselineid')
-    @mock.patch('sktm.db.SktDb.commit_testrun')
-    @mock.patch('sktm.db.SktDb.get_repoid')
-    @mock.patch('sktm.db.sqlite3')
-    def test_commit_patchtest(self, mock_sql, mock_get_repoid,
-                              mock_commit_testrun, mock_get_baselineid,
-                              mock_commit_series,
-                              mock_unset_patchset_pending):
-        """Ensure baseline is updated when current result is newer."""
-        # pylint: disable=too-many-arguments
-        testdb = SktDb(self.database_file)
-
-        mock_get_repoid.return_value = '1'
-        mock_commit_testrun.return_value = '2'
-        mock_get_baselineid.return_value = '3'
-        mock_commit_series.return_value = '4'
-        mock_unset_patchset_pending.return_value = None
-
-        patches = [(['patch_id'], 'patch_name', 'patch_url', 'base_url',
-                    'project_id', 'patch_date')]
-        testdb.commit_patchtest('baserepo', 'abcdef', patches, '5', '6', '7')
-
-        # Check if we have a proper INSERT query executed
-        execute_call_args = mock_sql.connect().cursor().execute.call_args[0]
-        self.assertIn('INSERT INTO patchtest', execute_call_args[0])
-        self.assertTupleEqual(
-            ('4', '3', '2'),
-            execute_call_args[1]
-        )
-
-        # Ensure the data was committed to the database
-        mock_sql.connect().commit.assert_called()
-
     @mock.patch('logging.debug')
     @mock.patch('sktm.db.SktDb.commit_patch')
     @mock.patch('sktm.db.SktDb.get_sourceid')

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -432,24 +432,6 @@ class TestDb(unittest.TestCase):  # pylint: disable=too-many-public-methods
         self.assertEqual(result, 1)
 
     @mock.patch('sktm.db.sqlite3')
-    def test_get_series_result(self, mock_sql):
-        """Ensure a testrun.result_id is returned."""
-        testdb = SktDb(self.database_file)
-        mock_sql.connect().cursor().fetchone.return_value = [1]
-        result = testdb.get_series_result(1)
-
-        self.assertEqual(result, 1)
-
-    @mock.patch('sktm.db.sqlite3')
-    def test_get_series_result_empty(self, mock_sql):
-        """Ensure None is returned when the results list is empty."""
-        testdb = SktDb(self.database_file)
-        mock_sql.connect().cursor().fetchone.return_value = None
-        result = testdb.get_series_result(1)
-
-        self.assertIsNone(result)
-
-    @mock.patch('sktm.db.sqlite3')
     def test_get_sourceid(self, mock_sql):
         """Ensure get_sourceid() retrieves a patchsource id."""
         testdb = SktDb(self.database_file)


### PR DESCRIPTION
#50 contains removal of `get_series_result` from Patchwork logic, but since no DB is passed to the function checking it in the first place the pull is good to be separate.

This should start the fixes for issue #80