### PR TITLE
check_pending: Rename series_id > series

### DIFF
--- a/sktm/__init__.py
+++ b/sktm/__init__.py
@@ -306,7 +306,7 @@ class watcher(object):
                 elif pjt == sktm.jtype.PATCHWORK:
                     patches = list()
                     slist = list()
-                    series = None
+                    series_id = None
                     bres = self.jk.get_result(self.jobname, bid)
                     rurl = self.jk.get_result_url(self.jobname, bid)
                     logging.info("result=%s", bres)


### PR DESCRIPTION
In 06b6ae590d6467742fe31cda8e007dea5698dda9, `series` was renamed to
`series_id`, which caused an exception in `sktm`:

```
Traceback (most recent call last):
  File "/home/skt/sktm/sktm.py", line 135, in <module>
    sw.wait_for_pending()
  File "/home/skt/sktm/sktm/__init__.py", line 367, in wait_for_pending
    self.check_pending()
  File "/home/skt/sktm/sktm/__init__.py", line 357, in check_pending
    self.db.commit_tested(patches, series_id)
UnboundLocalError: local variable 'series_id' referenced before assignment
```

The `series = None` earlier in the method did not get changed to
`series_id = None`, which caused the exception.

Fixes #89.

Signed-off-by: Major Hayden <major@redhat.com>
