### PR TITLE
Always use WARNING loglevel for HTTP connections

### DIFF
--- a/sktm.py
+++ b/sktm.py
@@ -82,6 +82,8 @@ def setup_logging(verbose):
         format="[%(process)d] %(asctime)s %(levelname)8s   %(message)s"
     )
     logger.setLevel(logging.WARNING - (verbose * 10))
+    logging.getLogger('requests').setLevel(logging.WARNING)
+    logging.getLogger('urllib3').setLevel(logging.WARNING)
 
 
 def cmd_baseline(sw, cfg):


### PR DESCRIPTION
While we want to know about possible problems, sktm debug logs get full
with debug logs from requests and urllib3 (which is used by requests on
background). Limit these two modules to always use WARNING level, no
matter what the setup for sktm actually is.

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>