### PR TITLE
Save patches dropped by filtering

### DIFF
--- a/db_migrations/02-remove-seriesid.sql
+++ b/db_migrations/02-remove-seriesid.sql
@@ -1,0 +1,14 @@
+ALTER TABLE patch RENAME TO patch_old;
+CREATE TABLE patch(
+        id INTEGER PRIMARY KEY,
+        name TEXT,
+        url TEXT,
+        date TEXT,
+        patchsource_id INTEGER,
+        FOREIGN KEY(patchsource_id) REFERENCES patchsource(id)
+);
+
+INSERT INTO patch
+        SELECT id, name, url, date, patchsource_id FROM patch_old;
+
+DROP TABLE patch_old;

--- a/sktm/__init__.py
+++ b/sktm/__init__.py
@@ -305,8 +305,6 @@ class watcher(object):
                     )
                 elif pjt == sktm.jtype.PATCHWORK:
                     patches = list()
-                    slist = list()
-                    series_id = None
                     bres = self.jk.get_result(self.jobname, bid)
                     rurl = self.jk.get_result_url(self.jobname, bid)
                     logging.info("result=%s", bres)
@@ -335,8 +333,6 @@ class watcher(object):
                                          patch.get("name"))
                             if self.restapi:
                                 projid = int(patch.get("project").get("id"))
-                                for series in patch.get("series"):
-                                    slist.append(series.get("id"))
                             else:
                                 projid = int(patch.get("project_id"))
                             patches.append((pid, patch.get("name"), patch_url,
@@ -348,13 +344,8 @@ class watcher(object):
                             raise Exception("Malfomed patch url: %s" %
                                             patch_url)
 
-                    try:
-                        series_id = max(set(slist), key=slist.count)
-                    except ValueError:
-                        pass
-
                     if bres != sktm.tresult.BASELINE_FAILURE:
-                        self.db.commit_tested(patches, series_id)
+                        self.db.commit_tested(patches)
                 else:
                     raise Exception("Unknown job type: %d" % pjt)
 


### PR DESCRIPTION
Dropped patches are always rechecked if no new patch passed the filter
script. Instead, save them as seen so they aren't checked all over again
each time.

Extract retrieving the info tuple and series IDs into separate method
(get_patch_info_from_url), which can be then used in both the original
place (saving tested patches) and when saving the dropped patches.

Fixes #100

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>