### PR TITLE
Executable.py: Remove interpreter directive

### DIFF
--- a/sktm/executable.py
+++ b/sktm/executable.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python2
-
 # Copyright (c) 2017 Red Hat, Inc. All rights reserved. This copyrighted
 # material is made available to anyone wishing to use, modify, copy, or
 # redistribute it subject to the terms and conditions of the GNU General


### PR DESCRIPTION
I make PR to remove interpreter directive in executable.py. Because `sktm` is not executed by a script, Shebang header in executable.py is removed.