### PR TITLE
Handle Jenkins errors

### DIFF
--- a/sktm/__init__.py
+++ b/sktm/__init__.py
@@ -45,6 +45,7 @@ def join_with_slash(base, *suffix):
 
 class tresult(enum.IntEnum):
     """Test result"""
+    ERROR = -1
     SUCCESS = 0
     MERGE_FAILURE = 1
     BUILD_FAILURE = 2

--- a/sktm/__init__.py
+++ b/sktm/__init__.py
@@ -349,24 +349,26 @@ class watcher(object):
     def check_pending(self):
         for (pjt, bid, cpw) in self.pj:
             if self.jk.is_build_complete(self.jobname, bid):
-                logging.info("job completed: jjid=%d; type=%d", bid, pjt)
+                bres = self.jk.get_result(self.jobname, bid)
+                rurl = self.jk.get_result_url(self.jobname, bid)
+                basehash = self.jk.get_base_hash(self.jobname, bid)
+                basedate = self.jk.get_base_commitdate(self.jobname, bid)
+
+                logging.info("job completed: "
+                             "type=%d; jjid=%d; result=%s; url=%s",
+                             pjt, bid, bres.name, rurl)
                 self.pj.remove((pjt, bid, cpw))
+
                 if pjt == sktm.jtype.BASELINE:
                     self.db.update_baseline(
                         self.baserepo,
-                        self.jk.get_base_hash(self.jobname, bid),
-                        self.jk.get_base_commitdate(self.jobname, bid),
-                        self.jk.get_result(self.jobname, bid),
+                        basehash,
+                        basedate,
+                        bres,
                         bid
                     )
                 elif pjt == sktm.jtype.PATCHWORK:
                     patches = list()
-                    bres = self.jk.get_result(self.jobname, bid)
-                    rurl = self.jk.get_result_url(self.jobname, bid)
-                    logging.info("result=%s", bres)
-                    logging.info("url=%s", rurl)
-                    basehash = self.jk.get_base_hash(self.jobname, bid)
-                    logging.info("basehash=%s", basehash)
 
                     patch_url_list = self.jk.get_patchwork(self.jobname, bid)
                     for patch_url in patch_url_list:

--- a/sktm/__init__.py
+++ b/sktm/__init__.py
@@ -50,7 +50,6 @@ class tresult(enum.IntEnum):
     BUILD_FAILURE = 2
     PUBLISH_FAILURE = 3
     TEST_FAILURE = 4
-    BASELINE_FAILURE = 5
 
 
 class jtype(enum.IntEnum):
@@ -369,22 +368,13 @@ class watcher(object):
                     logging.info("url=%s", rurl)
                     basehash = self.jk.get_base_hash(self.jobname, bid)
                     logging.info("basehash=%s", basehash)
-                    if bres == sktm.tresult.BASELINE_FAILURE:
-                        self.db.update_baseline(
-                            self.baserepo,
-                            basehash,
-                            self.jk.get_base_commitdate(self.jobname, bid),
-                            sktm.tresult.TEST_FAILURE,
-                            bid
-                        )
 
                     patch_url_list = self.jk.get_patchwork(self.jobname, bid)
                     for patch_url in patch_url_list:
                         patches.append(self.get_patch_info_from_url(cpw,
                                                                     patch_url))
 
-                    if bres != sktm.tresult.BASELINE_FAILURE:
-                        self.db.commit_tested(patches)
+                    self.db.commit_tested(patches)
                 else:
                     raise Exception("Unknown job type: %d" % pjt)
 

--- a/sktm/__init__.py
+++ b/sktm/__init__.py
@@ -48,7 +48,6 @@ class tresult(enum.IntEnum):
     SUCCESS = 0
     MERGE_FAILURE = 1
     BUILD_FAILURE = 2
-    PUBLISH_FAILURE = 3
     TEST_FAILURE = 4
 
 

--- a/sktm/__init__.py
+++ b/sktm/__init__.py
@@ -360,6 +360,10 @@ class watcher(object):
                              pjt, bid, bres.name, rurl)
                 self.pj.remove((pjt, bid, cpw))
 
+                if bres == sktm.tresult.ERROR:
+                    logging.warning("job completed with an error, ignoring")
+                    continue
+
                 if pjt == sktm.jtype.BASELINE:
                     self.db.update_baseline(
                         self.baserepo,

--- a/sktm/db.py
+++ b/sktm/db.py
@@ -434,7 +434,8 @@ class SktDb(object):
             baserepo:   Baseline Git repo URL.
             commithash: Commit SHA of the baseline commit.
             commitdate: Date of the commit.
-            result:     Result ID of the test run.
+            result:     Result ID of the test run (an sktm.tresult).
+                        Cannot be sktm.tresult.ERROR.
             build_id:   The build ID of the test run.
 
         """

--- a/sktm/jenkins.py
+++ b/sktm/jenkins.py
@@ -244,18 +244,6 @@ class skt_jenkins(object):
         if bstatus == "SUCCESS":
             return sktm.tresult.SUCCESS
 
-        # If build is UNSTABLE and all cmd_run steps are PASSED or FIXED
-        if bstatus == "UNSTABLE" and \
-                (set(self.__get_data_list(jobname, buildid,
-                                          "skt.cmd_run", "status")) <=
-                 set(["PASSED", "FIXED"])):
-            # If there was at least one baseline test failure
-            if self.get_baseretcode(jobname, buildid) != 0:
-                logging.warning("baseline failure found during patch testing")
-                return sktm.tresult.BASELINE_FAILURE
-
-            return sktm.tresult.SUCCESS
-
         # Find earliest (worst) step failure
         step_failure_result_list = [
             ("skt.cmd_merge", sktm.tresult.MERGE_FAILURE),

--- a/sktm/patchwork.py
+++ b/sktm/patchwork.py
@@ -658,7 +658,8 @@ class skt_patchwork2(PatchworkProject):
     def set_patch_check(self, pid, jurl, result):
         """
         Add a patch "check" for the specified patch, with the specified
-        Jenkins build URL and result (sktm.tresult).
+        Jenkins build URL and result (sktm.tresult). The result cannot be
+        sktm.tresult.ERROR.
 
         Args:
             pid:    The ID of the patch to add the "check" for.
@@ -987,7 +988,8 @@ class skt_patchwork(PatchworkProject):
     def set_patch_check(self, pid, jurl, result):
         """
         Add a patch "check" for the specified patch, with the specified
-        Jenkins build URL and result (sktm.tresult).
+        Jenkins build URL and result (sktm.tresult). The result cannot be
+        sktm.tresult.ERROR.
 
         Args:
             pid:    The ID of the patch to add the "check" for.

--- a/sktm/patchwork.py
+++ b/sktm/patchwork.py
@@ -677,10 +677,6 @@ class skt_patchwork2(PatchworkProject):
                    'description': 'Kernel CI testing'}
         if result == sktm.tresult.SUCCESS:
             payload['state'] = PW_CHECK_CHOICES['success']
-        elif result == sktm.tresult.BASELINE_FAILURE:
-            payload['state'] = PW_CHECK_CHOICES['warning']
-            payload['description'] = 'Baseline failure found while testing '
-            'this patch'
         else:
             payload['state'] = PW_CHECK_CHOICES['fail']
             payload['description'] = str(result)


### PR DESCRIPTION
This adds detection of test errors (infrastructure failures) and makes sktm ignore Jenkins builds which have them, so that baseline is not degraded and patches are held in `pendingpatches`, both to be rechecked on subsequent runs.