### PR TITLE
Use pendingjobs for baseline tests

### DIFF
--- a/db_migrations/03-add-pendingjobs.sql
+++ b/db_migrations/03-add-pendingjobs.sql
@@ -1,0 +1,5 @@
+CREATE TABLE pendingjobs(
+  id INTEGER PRIMARY KEY,
+  job_name TEXT,
+  build_id INTEGER
+);

--- a/db_migrations/04-alter-pendingpatches.sql
+++ b/db_migrations/04-alter-pendingpatches.sql
@@ -1,0 +1,8 @@
+-- NOTE: Apply this change only when no patches are pending.
+DROP TABLE pendingpatches;
+CREATE TABLE pendingpatches(
+  id INTEGER PRIMARY KEY,
+  pendingjob_id INTEGER,
+  timestamp INTEGER,
+  FOREIGN KEY(pendingjob_id) REFERENCES pendingjobs(id)
+);

--- a/sktm/__init__.py
+++ b/sktm/__init__.py
@@ -177,8 +177,7 @@ class watcher(object):
                 pw.lastpatch = lpatch
         self.pw.append(pw)
 
-    # FIXME Fix the name, this function doesn't check anything by itself
-    def check_baseline(self):
+    def start_baseline_test(self):
         """Submit a Jenkins job for testing a kernel baseline.
 
         A kernel baseline is a known good commit. That commit is used to test

--- a/sktm/db.py
+++ b/sktm/db.py
@@ -176,6 +176,18 @@ class SktDb(object):
 
         return self.cur.lastrowid
 
+    def delete_pending_job(self, job_name, build_id):
+        """Delete a pendingjob from the database.
+
+        Args:
+            job_name: Job name in Jenkins.
+            build_id: Build ID for the Jenkins job.
+        """
+        self.cur.execute(
+            'DELETE FROM pendingjobs WHERE job_name = ? and build_id = ?',
+            (job_name, build_id))
+        self.conn.commit()
+
     def get_pending_job_id(self, job_name, build_id):
         """Get a pending job ID.
 

--- a/sktm/db.py
+++ b/sktm/db.py
@@ -62,10 +62,9 @@ class SktDb(object):
 
                 CREATE TABLE pendingpatches(
                   id INTEGER PRIMARY KEY,
-                  pdate TEXT,
-                  patchsource_id INTEGER,
+                  pendingjob_id INTEGER,
                   timestamp INTEGER,
-                  FOREIGN KEY(patchsource_id) REFERENCES patchsource(id)
+                  FOREIGN KEY(pendingjob_id) REFERENCES pendingjobs(id)
                 );
 
                 CREATE TABLE pendingjobs(
@@ -159,6 +158,37 @@ class SktDb(object):
             return self.__create_sourceid(baseurl, project_id)
 
         return result[0]
+
+    def create_pending_job(self, job_name, build_id):
+        """Create a pending job entry.
+
+        Args:
+            job_name: Job name in Jenkins.
+            build_id: Build ID for the Jenkins job.
+
+        Returns: The pendingjob ID that was just added.
+        """
+        self.cur.execute(
+            "INSERT INTO pendingjobs (job_name, build_id) VALUES (?, ?)",
+            (job_name, build_id)
+        )
+        self.conn.commit()
+
+        return self.cur.lastrowid
+
+    def get_pending_job_id(self, job_name, build_id):
+        """Get a pending job ID.
+
+        Args:
+            job_name: Job name in Jenkins.
+            build_id: Build ID for the Jenkins job.
+        """
+        self.cur.execute(
+            'SELECT id FROM pendingjobs WHERE job_name = ? AND build_id = ?',
+            (job_name, build_id)
+        )
+        result = self.cur.fetchone()
+        return str(result[0])
 
     def get_last_checked_patch(self, baseurl, project_id):
         """Get the patch id of the last patch that was checked.
@@ -265,9 +295,10 @@ class SktDb(object):
         sourceid = self.__get_sourceid(baseurl, project_id)
         tstamp = int(time.time()) - exptime
 
-        self.cur.execute('SELECT id FROM pendingpatches WHERE '
-                         'patchsource_id = ? AND '
-                         'timestamp < ?',
+        self.cur.execute('SELECT pendingpatches.id FROM pendingpatches '
+                         'LEFT JOIN patch ON patch.id=pendingpatches.id'
+                         ' WHERE patch.patchsource_id = ? AND '
+                         'pendingpatches.timestamp < ?',
                          (sourceid, tstamp))
         for res in self.cur.fetchall():
             patchlist.append(res[0])
@@ -379,57 +410,50 @@ class SktDb(object):
 
         return result[0]
 
-    def set_patchset_pending(self, baseurl, project_id, series_data):
-        """Add a patch to pendingpatches or update an existing entry.
+    def set_patchset_pending(self, pendingjob_id, series_data):
+        """Add a patch to `pendingpatches` or update an existing entry.
 
-        Add each specified patch to the list of "pending" patches, with
-        specifed patch date, for specified Patchwork base URL and project ID,
-        and marked with current timestamp. Replace any previously added
-        patches with the same ID (bug: should be "same ID, project ID and
-        base URL").
+        Each entry in the `pendingpatches` table refers back to a patch in the
+        `patch` table.
 
         Args:
-            baseurl:     Base URL of the Patchwork instance the project ID and
-                         patch IDs belong to.
-            project_id:  ID of the Patchwork project the patch IDs belong to.
+            pendingjob_id: ID from the pendingjobs table for the Jenkins job
+                           that is testing the patches.
             series_data: List of info tuples for patches to add to the list,
                          where each tuple contains the patch ID and a free-form
                          patch date string.
 
         """
-        sourceid = self.__get_sourceid(baseurl, project_id)
         tstamp = int(time.time())
 
         logging.debug("setting patches as pending: %s", series_data)
-        self.cur.executemany('INSERT OR REPLACE INTO '
-                             'pendingpatches(id, pdate, patchsource_id, '
-                             'timestamp) '
-                             'VALUES(?, ?, ?, ?)',
-                             [(patch_id, patch_date, sourceid, tstamp) for
-                              (patch_id, patch_date) in series_data])
+        self.cur.executemany(
+            'INSERT OR REPLACE INTO pendingpatches '
+            '(id, pendingjob_id, timestamp) VALUES(?, ?, ?)',
+            [(patch_id, pendingjob_id, tstamp)
+             for (patch_id, patch_date) in series_data])
         self.conn.commit()
 
-    def __unset_patchset_pending(self, baseurl, patch_id_list):
-        """Remove a patch from the list of pending patches.
-
-        Remove each specified patch from the list of "pending" patches, for
-        the specified Patchwork base URL.
+    def unset_patchset_pending(self, job_name, build_id):
+        """Clean up pendingpatches and pendingjobs after a test is complete.
 
         Args:
-            baseurl:       Base URL of the Patchwork instance the patch IDs
-                           belong to.
-            patch_id_list: List of IDs of patches to be removed from the list.
+            job_name:   Jenkins job that tested the patches.
+            build_id:   Build ID from the Jenkins job.
 
         """
-        logging.debug("removing patches from pending list: %s", patch_id_list)
+        # Get the pendingjob ID
+        pendingjob_id = self.get_pending_job_id(job_name, build_id)
 
-        self.cur.executemany('DELETE FROM pendingpatches WHERE '
-                             'patchsource_id IN '
-                             '(SELECT DISTINCT id FROM patchsource WHERE '
-                             'baseurl = ?) '
-                             'AND id = ? ',
-                             [(baseurl, patch_id) for
-                              patch_id in patch_id_list])
+        # Delete the matching pendingpatches and pendingjobs entries
+        self.cur.executemany(
+            'DELETE FROM pendingpatches WHERE pendingjob_id = ?',
+            (pendingjob_id)
+        )
+        self.conn.commit()
+        self.cur.execute(
+            'DELETE FROM pendingjobs WHERE id = ?', (pendingjob_id)
+        )
         self.conn.commit()
 
     def update_baseline(self, baserepo, commithash, commitdate,
@@ -467,21 +491,6 @@ class SktDb(object):
                              'WHERE commitid = ? AND baserepo_id = ?',
                              (testrun_id, commithash, baserepo_id))
             self.conn.commit()
-
-    def commit_tested(self, patches):
-        """Saved tested patches.
-
-        Args:
-            patches:    List of patches that were tested
-        """
-        logging.debug("commit_tested: patches=%d", len(patches))
-        self.commit_series(patches)
-
-        for (patch_id, patch_name, patch_url, baseurl, project_id,
-             patch_date) in patches:
-            # TODO: Can accumulate per-project list instead of doing it one by
-            # one
-            self.__unset_patchset_pending(baseurl, [patch_id])
 
     def __commit_testrun(self, result, buildid):
         """Add a test run to the database.

--- a/sktm/db.py
+++ b/sktm/db.py
@@ -68,6 +68,12 @@ class SktDb(object):
                   FOREIGN KEY(patchsource_id) REFERENCES patchsource(id)
                 );
 
+                CREATE TABLE pendingjobs(
+                  id INTEGER PRIMARY KEY,
+                  job_name TEXT,
+                  build_id INTEGER
+                );
+
                 CREATE TABLE testrun(
                   id INTEGER PRIMARY KEY,
                   result_id INTEGER,

--- a/sktm/executable.py
+++ b/sktm/executable.py
@@ -89,7 +89,7 @@ def setup_logging(verbose):
 def cmd_baseline(sw, cfg):
     logging.info("checking baseline: %s [%s]", cfg.get("repo"), cfg.get("ref"))
     sw.set_baseline(cfg.get("repo"), cfg.get("ref"), cfg.get("cfgurl"))
-    sw.check_baseline()
+    sw.start_baseline_test()
 
 
 def cmd_patchwork(sw, cfg):

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -399,7 +399,7 @@ class TestDb(unittest.TestCase):  # pylint: disable=too-many-public-methods
     def test_set_patchset_pending(self, mock_sql, mock_log):
         """Ensure patches are added to the pendingpatch table."""
         testdb = SktDb(self.database_file)
-        testdb.set_patchset_pending('baseurl', '1', [('1', '2018-06-04')])
+        testdb.set_patchset_pending('1', [('1', '2018-06-04')])
 
         mock_sql.connect().cursor().executemany.assert_called_once()
         mock_sql.connect().commit.assert_called()
@@ -413,26 +413,27 @@ class TestDb(unittest.TestCase):  # pylint: disable=too-many-public-methods
             execute_call_args[0]
         )
 
-    @mock.patch('logging.debug')
-    @mock.patch('sktm.db.SktDb._SktDb__get_sourceid')
+    @mock.patch('sktm.db.SktDb.get_pending_job_id')
     @mock.patch('sktm.db.sqlite3')
-    def test_unset_patchset_pending(self, mock_sql, mock_get_sourceid,
-                                    mock_log):
+    def test_unset_patchset_pending(self, mock_sql, mock_getpendingjob):
         """Ensure patches are removed from the pendingpatch table."""
         # pylint: disable=W0212,E1101
         testdb = SktDb(self.database_file)
-        mock_get_sourceid.return_value = 1
+        mock_getpendingjob.return_value = '1'
 
-        testdb._SktDb__unset_patchset_pending('baseurl', ['1'])
+        testdb.unset_patchset_pending('skt-multiarch', '1')
 
-        # Ensure a debug log was written
-        mock_log.assert_called_once()
-
-        # Check if we have a proper DELETE query executed
+        # Ensure we deleted entries from pendingpatches
         execute_call_args = mock_sql.connect().cursor().executemany.\
             call_args[0]
         self.assertIn('DELETE FROM pendingpatches', execute_call_args[0])
-        self.assertEqual([('baseurl', '1')], execute_call_args[1])
+        self.assertEqual(('1'), execute_call_args[1])
+
+        # Ensure we deleted entries from pendingjobs
+        execute_call_args = mock_sql.connect().cursor().execute.\
+            call_args[0]
+        self.assertIn('DELETE FROM pendingjobs', execute_call_args[0])
+        self.assertEqual(('1'), execute_call_args[1])
 
         # Ensure the data was committed to the database
         mock_sql.connect().commit.assert_called()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -144,6 +144,26 @@ class TestDb(unittest.TestCase):  # pylint: disable=too-many-public-methods
         mock_sql.connect().commit.assert_called()
 
     @mock.patch('sktm.db.sqlite3')
+    def test_create_pendingjob(self, mock_sql):
+        """Ensure create_pending_job() makes a pendingjob record."""
+        # pylint: disable=W0212,E1101
+        testdb = SktDb(self.database_file)
+        mock_sql.connect().cursor().lastrowid = 1
+        result = testdb.create_pending_job('skt', '2')
+
+        self.assertEqual(result, 1)
+
+    @mock.patch('sktm.db.sqlite3')
+    def test_get_pendingjob(self, mock_sql):
+        """Ensure get_pending_job_id() retrieves a pendingjob record."""
+        # pylint: disable=W0212,E1101
+        testdb = SktDb(self.database_file)
+        mock_sql.connect().cursor().fetchone.return_value = [1]
+        result = testdb.get_pending_job_id('skt', '2')
+
+        self.assertEqual(result, '1')
+
+    @mock.patch('sktm.db.sqlite3')
     def test_create_repoid(self, mock_sql):
         """Ensure __create_repoid() inserts into DB and retrieves a repoid."""
         # pylint: disable=W0212,E1101


### PR DESCRIPTION
This PR adds a `pendingjobs` entry for baseline tests. It also renames the `check_baseline` function to `start_baseline_test` since that describes the function more accurately.

This is part of the work for #110, which allows `sktm` to check on pending jobs later without waiting.

- [ ] Requires #111 to merge first.