### PR TITLE
Always update baseline status

### DIFF
--- a/sktm/db.py
+++ b/sktm/db.py
@@ -446,6 +446,7 @@ class SktDb(object):
         logging.debug("previous result: %s", prev_res)
 
         if prev_res is None:
+            # This is a new commitid that we have not seen before
             logging.debug("creating baseline: repo=%s; commit=%s; result=%s",
                           baserepo, commithash, result)
             self.cur.execute('INSERT INTO '
@@ -454,7 +455,9 @@ class SktDb(object):
                              (baserepo_id, commithash, commitdate,
                               testrun_id))
             self.conn.commit()
-        elif result >= prev_res:
+        else:
+            # This commitid has been seen before and we need to update the
+            # testing status for it
             logging.debug("updating baseline: repo=%s; commit=%s; result=%s",
                           baserepo, commithash, result)
             self.cur.execute('UPDATE baseline SET testrun_id = ? '

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -500,29 +500,3 @@ class TestDb(unittest.TestCase):  # pylint: disable=too-many-public-methods
 
         # Ensure the data was committed to the database
         mock_sql.connect().commit.assert_called()
-
-    @mock.patch('logging.debug')
-    @mock.patch('sktm.db.SktDb._SktDb__get_baselineresult')
-    @mock.patch('sktm.db.SktDb._SktDb__commit_testrun')
-    @mock.patch('sktm.db.SktDb._SktDb__get_repoid')
-    @mock.patch('sktm.db.sqlite3')
-    def test_update_baseline_not_newer(self, mock_sql, mock_get_repoid,
-                                       mock_commit_testrun,
-                                       mock_get_baselineresult, mock_log):
-        """Ensure baseline is updated when current result is older."""
-        # pylint: disable=too-many-arguments
-        testdb = SktDb(self.database_file)
-
-        mock_sql.reset_mock()
-        mock_get_repoid.return_value = '1'
-        mock_commit_testrun.return_value = '1'
-        mock_get_baselineresult.return_value = 2
-
-        testdb.update_baseline('baserepo', 'abcdef', '2018-06-01', 1, '1')
-
-        # Ensure a debug log was written
-        mock_log.assert_called()
-
-        # Ensure we didn't execute any SQL queries or run a commit
-        mock_sql.connect().cursor().execute.assert_not_called()
-        mock_sql.connect().commit.assert_not_called()


### PR DESCRIPTION
When a baseline test is complete, sktm only updates the baseline
record if the status of the commitid got worse (passed before but
failed now). It should always update the status regardless of
the tests improving or getting worse.

Ensure the baseline status is always updated whether it improved or
worsened.

Fixes #85.

Signed-off-by: Major Hayden <major@redhat.com>