### PR TITLE
Remove the restapi attribute of the watcher

### DIFF
--- a/sktm/executable.py
+++ b/sktm/executable.py
@@ -158,9 +158,8 @@ def cmd_patchwork(sw, cfg):
     logging.info("checking patchwork: %s [%s]", cfg.get("baseurl"),
                  cfg.get("project"))
     sw.set_baseline(cfg.get("repo"), cfgurl=cfg.get("cfgurl"))
-    sw.set_restapi(cfg.get("restapi"))
     sw.add_pw(cfg.get("baseurl"), cfg.get("project"), cfg.get("lastpatch"),
-              cfg.get("apikey"), cfg.get('skip'))
+              cfg.get('restapi'), cfg.get("apikey"), cfg.get('skip'))
     sw.check_patchwork()
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -68,11 +68,6 @@ class TestInit(unittest.TestCase):
         self.assertEqual(self.watcher_obj.baseref, baseref)
         self.assertEqual(self.watcher_obj.cfgurl, cfgurl)
 
-    def test_set_restapi(self):
-        """Ensure set_restapi() sets self.restapi properly."""
-        self.watcher_obj.set_restapi(True)
-        self.assertEqual(self.watcher_obj.restapi, True)
-
     @mock.patch('sktm.watcher.check_pending', Mock(return_value=True))
     @mock.patch('logging.info')
     def test_wait_for_pending_done(self, mock_logging):


### PR DESCRIPTION
The attribute is specific to the Patchwork interface and not needed for
the watcher for anything besides creating it.

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>