### PR TITLE
Fix retrieval of the applied patches

### DIFF
--- a/sktm/jenkins.py
+++ b/sktm/jenkins.py
@@ -282,7 +282,16 @@ class JenkinsProject(object):
             The list of Patchwork patch URLs, in the order the patches should
             be applied in.
         """
-        return self.__get_cfg_data_uniform(buildid, "skt.cmd_merge", "pw")
+        merge_data = self.__get_cfg_data_uniform(buildid,
+                                                 "skt.cmd_merge",
+                                                 'merge_queue')
+        patch_list = [patch_url for merge_type, patch_url in merge_data
+                      if merge_type == 'pw']
+        if len(merge_data) != len(patch_list):
+            raise Exception('Only "pw" type of applied patches is supported '
+                            'but this is the data we got: %s' % merge_data)
+
+        return patch_list
 
     def get_baseretcode(self, buildid):
         """


### PR DESCRIPTION
When skt was modified to accept a combination of merge options, the
format of the parsed options was modified. This change was not
propagated to sktm, resulting in the patches never marked as tested and
stuck in the pending state because the patch URLs weren't being
retrieved correctly.

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>